### PR TITLE
Upgrade to ubuntu 18.04 and golang 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 MAINTAINER Leif Johansson <leifj@sunet.se>
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
-RUN apt-get -y update
-RUN apt-get -y install python python-dev python-pip mercurial build-essential libgeoip-dev git-core pkgconf wget
-RUN wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
+RUN /bin/sed -i s/archive.ubuntu.com/se.archive.ubuntu.com/g /etc/apt/sources.list
+RUN apt-get -y update && \
+	apt-get -y install python python-dev python-pip mercurial build-essential libgeoip-dev git-core pkgconf golang-go && \
+	apt-get clean
 ENV GOPATH /opt/geodns
 ENV DNSDIR /etc/geodns
 ENV PATH /usr/local/go/bin:/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
Geodns have stopped to build on 1.8, so this upgrades golang to 1.10 in
ubuntu 18.04.